### PR TITLE
Improve time handling

### DIFF
--- a/influx.go
+++ b/influx.go
@@ -86,7 +86,7 @@ func (i *InfluxClient) Write(point Point) error {
 			"tx_host": point.TxHost,
 		},
 		fields,
-		time.Now())
+		point.Time)
 
 	if err != nil {
 		return err

--- a/influx.go
+++ b/influx.go
@@ -92,7 +92,7 @@ func (i *InfluxClient) Write(point Point) error {
 		return err
 	}
 
-	batchConfig := client.BatchPointsConfig{Database: i.db, Precision: ""}
+	batchConfig := client.BatchPointsConfig{Database: i.db, Precision: "s"}
 	bp, err := client.NewBatchPoints(batchConfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Change precision to seconds

The minimum summary duration for fping is 1 second, so having ns precision is quite useless.

## Use timestamp from fping output

The set of measurements from fping is atomic, and thus should have the same timestamp in InfluxDB.