### PR TITLE
Fix path to influxdb1-client/v2

### DIFF
--- a/influx.go
+++ b/influx.go
@@ -26,7 +26,7 @@ SOFTWARE.
 package main
 
 import (
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/influxdb1-client/v2"
 	"time"
 )
 

--- a/infping.go
+++ b/infping.go
@@ -34,7 +34,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/influxdb1-client/v2"
 	"github.com/spf13/viper"
 )
 


### PR DESCRIPTION
They changed the path to the client library in preparation for InfluxDB 2.0 release.