### PR TITLE
Fix fping section in infping_sample.json

### DIFF
--- a/infping_sample.json
+++ b/infping_sample.json
@@ -7,7 +7,7 @@
 		"secure": false,
 		"db": "infping"
 	},
-	"infping": {
+	"fping": {
 		"backoff": "1",
 		"retries": "0",
 		"tos": "0",


### PR DESCRIPTION
This section should be called "fping", but in the example was accidentally called "infping". This means using the example config as a starting point does not actually apply the configured fping settings.

This fixes the example.